### PR TITLE
Update promptfoo package

### DIFF
--- a/pkgs/by-name/pr/promptfoo/package.nix
+++ b/pkgs/by-name/pr/promptfoo/package.nix
@@ -26,8 +26,9 @@ buildNpmPackage rec {
     maintainers = [ lib.maintainers.nathanielbrough ];
   };
 
-   # Prevent Playwright download as that will cause the package build to fail
-  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1";
+  env = {
+    PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = 1;
+  };
 
   # Remove broken symlinks after installation
   postInstall = ''

--- a/pkgs/by-name/pr/promptfoo/package.nix
+++ b/pkgs/by-name/pr/promptfoo/package.nix
@@ -30,9 +30,8 @@ buildNpmPackage rec {
     PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = 1;
   };
 
-  # Remove broken symlinks after installation
   postInstall = ''
-    rm -f $out/lib/node_modules/promptfoo/node_modules/app
-    rm -f $out/lib/node_modules/promptfoo/node_modules/promptfoo-docs
+    rm $out/lib/node_modules/promptfoo/node_modules/app
+    rm $out/lib/node_modules/promptfoo/node_modules/promptfoo-docs
   '';
 }

--- a/pkgs/by-name/pr/promptfoo/package.nix
+++ b/pkgs/by-name/pr/promptfoo/package.nix
@@ -6,16 +6,16 @@
 
 buildNpmPackage rec {
   pname = "promptfoo";
-  version = "0.79.0";
+  version = "0.115.1";
 
   src = fetchFromGitHub {
     owner = "promptfoo";
     repo = "promptfoo";
     rev = "${version}";
-    hash = "sha256-sMBgjxPzG3SJ7RS4oTtOq7hJ1MYaKW3/6FF8Pn5l89c=";
+    hash = "sha256-KGi5IV4R0WOvshTrVaVN3u0pO8as/A4/858JlFOdc0c=";
   };
 
-  npmDepsHash = "sha256-tnzeEFEc/BMN/VsoNHWJIWDOvupHfddqI6020Q4M0RM=";
+  npmDepsHash = "sha256-vkZx2c5vvjHM8kSLukL7YQwRLnwSdFLa+xKhn+ekuts=";
 
   dontNpmBuild = true;
 

--- a/pkgs/by-name/pr/promptfoo/package.nix
+++ b/pkgs/by-name/pr/promptfoo/package.nix
@@ -30,4 +30,10 @@ buildNpmPackage rec {
 
    # Prevent Playwright download as that will cause the package build to fail
   PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1";
+
+  # Remove broken symlinks after installation
+  postInstall = ''
+    rm -f $out/lib/node_modules/promptfoo/node_modules/app
+    rm -f $out/lib/node_modules/promptfoo/node_modules/promptfoo-docs
+  '';
 }

--- a/pkgs/by-name/pr/promptfoo/package.nix
+++ b/pkgs/by-name/pr/promptfoo/package.nix
@@ -27,4 +27,7 @@ buildNpmPackage rec {
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.nathanielbrough ];
   };
+
+   # Prevent Playwright download as that will cause the package build to fail
+  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1";
 }

--- a/pkgs/by-name/pr/promptfoo/package.nix
+++ b/pkgs/by-name/pr/promptfoo/package.nix
@@ -17,8 +17,6 @@ buildNpmPackage rec {
 
   npmDepsHash = "sha256-vkZx2c5vvjHM8kSLukL7YQwRLnwSdFLa+xKhn+ekuts=";
 
-  dontNpmBuild = true;
-
   meta = {
     description = "Test your prompts, models, RAGs. Evaluate and compare LLM outputs, catch regressions, and improve prompt quality";
     mainProgram = "promptfoo";

--- a/pkgs/by-name/pr/promptfoo/package.nix
+++ b/pkgs/by-name/pr/promptfoo/package.nix
@@ -6,16 +6,16 @@
 
 buildNpmPackage rec {
   pname = "promptfoo";
-  version = "0.115.1";
+  version = "0.115.3";
 
   src = fetchFromGitHub {
     owner = "promptfoo";
     repo = "promptfoo";
     rev = "${version}";
-    hash = "sha256-KGi5IV4R0WOvshTrVaVN3u0pO8as/A4/858JlFOdc0c=";
+    hash = "sha256-JBDz3kb++oR84mcU5Fxk28NCc5OfLThvBpAD7GiMZx4=";
   };
 
-  npmDepsHash = "sha256-vkZx2c5vvjHM8kSLukL7YQwRLnwSdFLa+xKhn+ekuts=";
+  npmDepsHash = "sha256-1SfaX3XrmSVXpZKuSbM4LdO7F4d0NCpa1QcpasEMoBw=";
 
   meta = {
     description = "Test your prompts, models, RAGs. Evaluate and compare LLM outputs, catch regressions, and improve prompt quality";


### PR DESCRIPTION
This PR attempts to fix the `promptfoo` package from failing to build.

Initial error:
```
...
error: builder for '/nix/store/zm2lfyhva9kmxajhch5xjm59ryhny66y-promptfoo-0.79.0.drv' failed with exit code 1;
       last 25 log lines:
       > node_modules/better-sqlite3/build/gyp-mac-tool: interpreter directive changed from "#!/usr/bin/env python3" to "/nix/store/v0vy1c59f0vf71h64caw17hzymvg0zms-python3-3.12.10/bin/python3"
       > node_modules/nice-napi/build/gyp-mac-tool: interpreter directive changed from "#!/usr/bin/env python3" to "/nix/store/v0vy1c59f0vf71h64caw17hzymvg0zms-python3-3.12.10/bin/python3"
       > Finished npmConfigHook
       > patchPhase completed in 42 seconds
       > Running phase: updateAutotoolsGnuConfigScriptsPhase
       > Running phase: configurePhase
       > no configure script, doing nothing
       > Running phase: buildPhase
       > no Makefile or custom buildPhase, doing nothing
       > Running phase: installPhase
       > Executing npmInstallHook
       >
       > up to date, audited 1927 packages in 3s
       >
       > 444 packages are looking for funding
       >   run `npm fund` for details
       >
       > found 0 vulnerabilities
       > Finished npmInstallHook
       > Running phase: fixupPhase
       > checking for references to /private/tmp/nix-build-promptfoo-0.79.0.drv-0/ in /nix/store/1wp25wzcig55f7xjmshymp5666gsxs64-promptfoo-0.79.0...
       > patching script interpreter paths in /nix/store/1wp25wzcig55f7xjmshymp5666gsxs64-promptfoo-0.79.0
       > ERROR: noBrokenSymlinks: the symlink /nix/store/1wp25wzcig55f7xjmshymp5666gsxs64-promptfoo-0.79.0/lib/node_modules/promptfoo/node_modules/promptfoo-docs points to a missing target: /nix/store/1wp25wzcig55f7xjmshymp5666gsxs64-promptfoo-0.79.0/lib/node_modules/promptfoo/site
       > ERROR: noBrokenSymlinks: the symlink /nix/store/1wp25wzcig55f7xjmshymp5666gsxs64-promptfoo-0.79.0/lib/node_modules/promptfoo/node_modules/nextui points to a missing target: /nix/store/1wp25wzcig55f7xjmshymp5666gsxs64-promptfoo-0.79.0/lib/node_modules/promptfoo/src/web/nextui
       > ERROR: noBrokenSymlinks: found 2 dangling symlinks, 0 reflexive symlinks and 0 unreadable symlinks
       For full logs, run 'nix log /nix/store/zm2lfyhva9kmxajhch5xjm59ryhny66y-promptfoo-0.79.0.drv'.
...
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

### Steps taken

#### 1. Upgrade `promptfoo` to newer version

The initial upgrade was done by running `nix-shell -p nix-update` and then inside that shell `nix-update promptfoo`. This updated the version number and various hashes.

#### 2. Fix build

See the commit messages for which error each change is trying to address.

After these changes I was able to successfully build the package using `nix-build -A promptfoo`.

After that I was able to install promptfoo using `nix-env -f . -iA promptfoo`.

Finally, I was able to run `promptfoo`:
```
% nix-env -f . -iA promptfoo
installing 'promptfoo-0.115.3'
building '/nix/store/lidkacp847l2pw7g2d877ivaahqqwq96-user-environment.drv'...
% type promptfoo
promptfoo is /Users/roeland/.nix-profile/bin/promptfoo
% promptfoo --version
0.115.3
```

I've also tested it by trying out `promptfoo eval` and `promptfoo view` on an existing `promptfooconfig.yaml`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
